### PR TITLE
Add multiple-block versions of SWIFFT APIs with OpenMP implementations

### DIFF
--- a/.github/workflows/new-code.yml
+++ b/.github/workflows/new-code.yml
@@ -55,7 +55,7 @@ jobs:
       run: for conf in "" -omp; do build${conf}/test/swifft_catch; done
     # make package
     - name: make package
-      run: for conf in "" -omp; do (mkdir pack${conf} && cd pack${conf} && mkdir lib package && cp -p ../build/src/libswifft.{a,so} lib/ && cp -rp ../include . && tar czfv package/libswifft-${{ steps.get_version.outputs.version }}.tgz lib include); done
+      run: for conf in "" -omp; do (mkdir pack${conf} && cd pack${conf} && mkdir lib package && cp -p ../build/src/libswifft.{a,so} lib/ && cp -rp ../include . && tar czfv package/libswifft-${{ steps.get_version.outputs.version }}${conf}.tgz lib include); done
     # upload package
     - name: upload package
       uses: actions/upload-artifact@v2

--- a/.github/workflows/new-code.yml
+++ b/.github/workflows/new-code.yml
@@ -43,17 +43,19 @@ jobs:
     - name: mkdir
       run: mkdir build
     - name: cmake build
-      run: cmake -DCMAKE_BUILD_TYPE=Release -Bbuild -H.
+      run: |
+        cmake -DCMAKE_BUILD_TYPE=Release -Bbuild -H.
+        cmake -DCMAKE_BUILD_TYPE=Release -DSWIFFT_ENABLE_OPENMP=On -Bbuild-omp -H.
     - name: cmake make
-      run: cmake --build build/ --target all
+      run: for conf in "" -omp; do cmake --build build${conf}/ --target all; done
       env:
         MAKEFLAGS: "-j2"
     # run tests
     - name: run main tests
-      run: build/test/swifft_catch
+      run: for conf in "" -omp; do build${conf}/test/swifft_catch; done
     # make package
     - name: make package
-      run: mkdir -p lib package && cp -p build/src/libswifft.{a,so} lib/ && tar czfv package/libswifft-${{ steps.get_version.outputs.version }}.tgz lib include
+      run: for conf in "" -omp; do (mkdir pack${conf} && cd pack${conf} && mkdir lib package && cp -p ../build/src/libswifft.{a,so} lib/ && cp -rp ../include . && tar czfv package/libswifft-${{ steps.get_version.outputs.version }}.tgz lib include); done
     # upload package
     - name: upload package
       uses: actions/upload-artifact@v2
@@ -61,3 +63,10 @@ jobs:
       with:
         name: libswifft-${{ steps.get_version.outputs.version }}.tgz
         path: package/libswifft-${{ steps.get_version.outputs.version }}.tgz
+    # upload package omp
+    - name: upload package omp
+      uses: actions/upload-artifact@v2
+      if: ${{ !env.ACT }}
+      with:
+        name: libswifft-${{ steps.get_version.outputs.version }}-omp.tgz
+        path: package/libswifft-${{ steps.get_version.outputs.version }}-omp.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN wget https://github.com/catchorg/Catch2/archive/${CATCH2_VERSION}.zip -O Cat
 RUN (CATCH2_VER=$(echo ${CATCH2_VERSION} | sed 's~^v~~'); ln -s Catch2-${CATCH2_VER} Catch2 && cd Catch2 && cmake -Bbuild -H. -DBUILD_TESTING=OFF && MAKEFLAGS=$(( $(nproc) + 1 )) cmake --build build/ --target install)
 
 # get and build LibSWIFFT source code
-ARG LIBSWIFFT_VERSION=v1.0.0
+ARG LIBSWIFFT_VERSION=v1.1.0
 ARG LIBSWIFFT_MCFLAGS=-march=native
 RUN wget https://github.com/gvilitechltd/LibSWIFFT/archive/${LIBSWIFFT_VERSION}.zip -O LibSWIFFT.zip && unzip LibSWIFFT.zip -d .
 RUN (LIBSWIFFT_VER=$(echo ${LIBSWIFFT_VERSION} | sed 's~^v~~'); ln -s LibSWIFFT-${LIBSWIFFT_VER} LibSWIFFT && cd LibSWIFFT && cmake -Bbuild -H. -DCMAKE_BUILD_TYPE=Release -DSWIFFT_MACHINE_COMPILE_FLAGS=${LIBSWIFFT_MCFLAGS} && MAKEFLAGS=$(( $(nproc) + 1 )) cmake --build build/ --target all)

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "LibSWIFFT"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "1.0.0"
+PROJECT_NUMBER         = "1.1.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ Nevertheless, the family is not pseudorandom, due to the homomorphism property, 
 LibSWIFFT was implemented with reference to the [SWIFFTX submission to NIST](https://csrc.nist.gov/projects/hash-functions/sha-3-project) and provides the same SWIFFT hash function that is part of the submission. High speed is achieved using various code optimization techniques, including SIMD instructions that are very natural for the implementation of the SWIFFT function. Compared to the SWIFFT code in the submission, LibSWIFFT adds the following:
 
 1. Automatic library initialization using build-time generation of internal tables.
-2. Convenient APIs, including for homomorphic operations, for computing SWIFFT on short inputs.
+2. Convenient APIs, including for homomorphic operations and parallel variations based on OpemMP, for computing SWIFFT on short inputs.
 3. Support for input vectors of either binary-valued (in {0,1}) or trinary-valued (in {-1,0,1}) elements.
 4. Bug fixes with respect to the reference submission, in particular related to the homomorphism property.
 5. Performance improvements compared to the reference submission.
 6. Support for newer CPU instruction sets: AVX, AVX2, and AVX512.
-7. Over 20 test-cases providing excellent coverage of the APIs and the mathematical properties of SWIFFT.
+7. Over 30 test-cases providing excellent coverage of the APIs and the mathematical properties of SWIFFT.
 
 Formally, LibSWIFFT provides a single hash function that maps from an input domain `Z_2^{2048}` (taking 256B) to an output domain `Z_{257}^{64}` (taking 128B, at 2B per element) and then to a compact domain `Z_{256}^{65}` (taking 65B). The computation of the first map is done over `Z_{257}`. The homomorphism property applies to the input and output domains, but not to the compact domain, and is revealed when the binary-valued input domain is naturally embedded in `Z_{257}^{2048}`. Generally, it is computationally hard to find a binary-valued pre-image given an output computed as the sum of `N` outputs corresponding to known binary-valued pre-images. On the other hand, it is easy to find a small-valued pre-image (over `Z_{257}^{2048}`) when `N` is small, since it is simply the sum of the known pre-images due to the homomorphism property.
 
@@ -92,7 +92,7 @@ SWIFFT_Compute(input, sign, output); /* compute the hash of the signed input int
 SWIFFT_Compact(output, compact); /* optionally, compact the hash */
 ```
 
-Buffers must be memory-aligned using `SWIFFT_ALIGN` in order to avoid a segmentation fault when passed to `LibSWIFFT` functions. The transformation functions `SWIFFT_{Compute,Compact}Multiple{,Signed}*` apply operations to multiple blocks. The arithmetic functions `SWIFFT_{Const,}{Set,Add,Sub,Mul}*` provide vectorized and homomorphic operations on an output block.
+Buffers must be memory-aligned in order to avoid a segmentation fault when passed to `LibSWIFFT` functions: statically allocated buffers should be aligned using `SWIFFT_ALIGN`, and dynamically allocated buffers should use an alignment of `SWIFFT_ALIGNMENT`, e.g., via `aligned_alloc` function in `stdlib.h`. The transformation functions `SWIFFT_{Compute,Compact}Multiple{,Signed}*` apply operations to multiple blocks. The arithmetic functions `SWIFFT_{Const,}{Set,Add,Sub,Mul}*` provide vectorized and homomorphic operations on an output block, while `SWIFFT_{Const,}{Set,Add,sub,Mul}Multiple*` provide corresponding operations to multiple blocks.
 
 Typical code using the C++ API:
 
@@ -155,6 +155,12 @@ By default, the build will be for the native machine. To build with different ma
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Release ../.. -DSWIFFT_MACHINE_COMPILE_FLAGS=-march=skylake
+```
+
+To build with OpemMP, in particular for parallelizing multiple-block operations, add `-DSWIFFT_ENABLE_OPENMP=on` on the `cmake` command line, for example:
+
+```sh
+cmake -DCMAKE_BUILD_TYPE=Release ../.. -DSWIFFT_ENABLE_OPENMP=On
 ```
 
 After building, run the tests-executable from the `build/release` directory:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Nevertheless, the family is not pseudorandom, due to the homomorphism property, 
 LibSWIFFT was implemented with reference to the [SWIFFTX submission to NIST](https://csrc.nist.gov/projects/hash-functions/sha-3-project) and provides the same SWIFFT hash function that is part of the submission. High speed is achieved using various code optimization techniques, including SIMD instructions that are very natural for the implementation of the SWIFFT function. Compared to the SWIFFT code in the submission, LibSWIFFT adds the following:
 
 1. Automatic library initialization using build-time generation of internal tables.
-2. Convenient APIs, including for homomorphic operations and parallel variations based on OpemMP, for computing SWIFFT on short inputs.
+2. Convenient APIs, including for homomorphic operations and parallel variations based on OpenMP, for computing SWIFFT on short inputs.
 3. Support for input vectors of either binary-valued (in {0,1}) or trinary-valued (in {-1,0,1}) elements.
 4. Bug fixes with respect to the reference submission, in particular related to the homomorphism property.
 5. Performance improvements compared to the reference submission.
@@ -157,7 +157,7 @@ By default, the build will be for the native machine. To build with different ma
 cmake -DCMAKE_BUILD_TYPE=Release ../.. -DSWIFFT_MACHINE_COMPILE_FLAGS=-march=skylake
 ```
 
-To build with OpemMP, in particular for parallelizing multiple-block operations, add `-DSWIFFT_ENABLE_OPENMP=on` on the `cmake` command line, for example:
+To build with OpenMP, in particular for parallelizing multiple-block operations, add `-DSWIFFT_ENABLE_OPENMP=on` on the `cmake` command line, for example:
 
 ```sh
 cmake -DCMAKE_BUILD_TYPE=Release ../.. -DSWIFFT_ENABLE_OPENMP=On

--- a/cmake/swifft_defaults.cmake
+++ b/cmake/swifft_defaults.cmake
@@ -3,3 +3,12 @@ if(NOT DEFINED SWIFFT_MACHINE_COMPILE_FLAGS)
 endif()
 
 set(SWIFFT_DEFAULT_FILE_COMPILE_FLAGS "${SWIFFT_MACHINE_COMPILE_FLAGS}")
+
+if(SWIFFT_ENABLE_OPENMP)
+        find_package(OpenMP REQUIRED)
+        if(OpenMP_FOUND)
+                set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+                set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+        endif()
+endif()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ copyright = '2021, Gvili Tech Ltd'
 author = 'Gvili Tech Ltd'
 
 # The full version, including alpha/beta/rc tags
-release = 'v1.0.0'
+release = 'v1.1.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,7 +47,7 @@ sets to take advantage of available hardware acceleration.
 Production-Ready
 ----------------
 
-LibSWIFFT v1.0.0 ships with over 20 test-cases including millions of checks that
+LibSWIFFT v1.1.0 ships with over 30 test-cases including millions of checks that
 provide excellent coverage of the library's code and the mathematical properties
 of the SWIFFT function it implements:
 
@@ -56,7 +56,7 @@ of the SWIFFT function it implements:
     $ ./test/swifft_catch
 
     ===============================================================================
-    All tests passed (6646079 assertions in 23 test cases)
+    All tests passed (6648383 assertions in 32 test cases)
 
 LibSWIFFT also ships with detailed documentation, including references for its
 :libswifft:`C API <swifft.h>` and :libswifft:`C++ API <LibSwifft>`. It has a

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -73,7 +73,7 @@ By default, the build will be for the native machine. To build with different ma
 
     cmake -DCMAKE_BUILD_TYPE=Release ../.. -DSWIFFT_MACHINE_COMPILE_FLAGS=-march=skylake
 
-To build with OpemMP, in particular for parallelizing multiple-block operations, add `-DSWIFFT_ENABLE_OPENMP=on` on the `cmake` command line, for example:
+To build with OpenMP, in particular for parallelizing multiple-block operations, add `-DSWIFFT_ENABLE_OPENMP=on` on the `cmake` command line, for example:
 
 .. code-block:: sh
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -12,11 +12,11 @@ The code repository can be cloned using `git <https://git-scm.com>`_:
     git clone https://github.com/gvilitechltd/LibSWIFFT
     cd LibSWIFFT
 
-To switch to a specific version of LibSWIFFT, such as v1.0.0, use:
+To switch to a specific version of LibSWIFFT, such as `v1.1.0`, use:
 
 .. code-block:: sh
 
-    git checkout v1.0.0
+    git checkout v1.1.0
 
 As an alternative to getting the repository, a specific version of LibSWIFFT can
 be obtained from `GitHub <https://github.com/gvilitechltd/LibSWIFFT>`_ by
@@ -25,9 +25,9 @@ Then, unpack the archive and change into the unpacked directory, e.g.:
 
 .. code-block:: sh
 
-    wget https://github.com/gvilitechltd/LibSWIFFT/archive/v1.0.0.zip
-    unzip v1.0.0.zip
-    cd LibSWIFFT-1.0.0
+    wget https://github.com/gvilitechltd/LibSWIFFT/archive/v1.1.0.zip
+    unzip v1.1.0.zip
+    cd LibSWIFFT-1.1.0
 
 Building LibSWIFFT
 ------------------
@@ -73,6 +73,12 @@ By default, the build will be for the native machine. To build with different ma
 
     cmake -DCMAKE_BUILD_TYPE=Release ../.. -DSWIFFT_MACHINE_COMPILE_FLAGS=-march=skylake
 
+To build with OpemMP, in particular for parallelizing multiple-block operations, add `-DSWIFFT_ENABLE_OPENMP=on` on the `cmake` command line, for example:
+
+.. code-block:: sh
+
+    cmake -DCMAKE_BUILD_TYPE=Release ../.. -DSWIFFT_ENABLE_OPENMP=On
+
 After building, run the tests-executable from the `build/release` directory:
 
 .. code-block:: sh
@@ -117,7 +123,7 @@ Typical code using the C API:
     SWIFFT_Compute(input, sign, output); /* compute the hash of the signed input into the output */
     SWIFFT_Compact(output, compact); /* optionally, compact the hash */
 
-Buffers must be memory-aligned using `SWIFFT_ALIGN` in order to avoid a segmentation fault when passed to `LibSWIFFT` functions. The transformation functions `SWIFFT_{Compute,Compact}Multiple{,Signed}*` apply operations to multiple blocks. The arithmetic functions `SWIFFT_{Const,}{Set,Add,Sub,Mul}*` provide vectorized and homomorphic operations on an output block.
+Buffers must be memory-aligned in order to avoid a segmentation fault when passed to `LibSWIFFT` functions: statically allocated buffers should be aligned using `SWIFFT_ALIGN`, and dynamically allocated buffers should use an alignment of `SWIFFT_ALIGNMENT`, e.g., via `aligned_alloc` function in `stdlib.h`. The transformation functions `SWIFFT_{Compute,Compact}Multiple{,Signed}*` apply operations to multiple blocks. The arithmetic functions `SWIFFT_{Const,}{Set,Add,Sub,Mul}*` provide vectorized and homomorphic operations on an output block, while `SWIFFT_{Const,}{Set,Add,sub,Mul}Multiple*` provide corresponding operations to multiple blocks.
 
 Typical code using the C++ API:
 

--- a/include/libswifft/swifft.h
+++ b/include/libswifft/swifft.h
@@ -83,6 +83,13 @@ void SWIFFT_ConstSub(BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
 void SWIFFT_ConstMul(BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
 	const int16_t operand);
 
+//! \brief Sets a SWIFFT hash value to another, element-wise.
+//!
+//! \param[in,out] output the hash value of SWIFFT to modify.
+//! \param[in] operand the hash value to set to.
+void SWIFFT_Set(BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
+	const BitSequence operand[SWIFFT_OUTPUT_BLOCK_SIZE]);
+
 //! \brief Adds a SWIFFT hash value to another, element-wise.
 //!
 //! \param[in,out] output the hash value of SWIFFT to modify.
@@ -103,6 +110,98 @@ void SWIFFT_Sub(BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
 //! \param[in] operand the hash value to multiply by.
 void SWIFFT_Mul(BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
 	const BitSequence operand[SWIFFT_OUTPUT_BLOCK_SIZE]);
+
+//! \brief Computes the FFT phase of SWIFFT for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in] input the blocks of input, each of 256 bytes (2048 bits).
+//! \param[in] sign the blocks of sign bits corresponding to blocks of input of 256 bytes (2048 bits).
+//! \param[in] m number of 8-elements in the input.
+//! \param[out] fftout the blocks of FFT-output elements, totaling N*m.
+void SWIFFT_fftMultiple(int nblocks, const BitSequence * LIBSWIFFT_RESTRICT input, const BitSequence * LIBSWIFFT_RESTRICT sign, int m, int16_t * LIBSWIFFT_RESTRICT fftout);
+
+//! \brief Computes the FFT-sum phase of SWIFFT for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in] ikey the SWIFFT key.
+//! \param[in] ifftout the blocks of FFT-output elements, totaling N*m
+//! \param[in] m number of 8-elements in the input.
+//! \param[out] iout the blocks of output elements, each of 64 double-bytes (1024 bits).
+void SWIFFT_fftsumMultiple(int nblocks, const int16_t * LIBSWIFFT_RESTRICT ikey,
+        const int16_t * LIBSWIFFT_RESTRICT ifftout, int m, int16_t * LIBSWIFFT_RESTRICT iout);
+
+//! \brief Compacts a hash value of SWIFFT for multiple blocks.
+//! The result is not composable with other compacted hash values.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in] output the hash value of SWIFFT, of size 128 bytes (1024 bit).
+//! \param[out] compact the compacted hash value of SWIFFT, of size 64 bytes (512 bit).
+void SWIFFT_CompactMultiple(int nblocks, const BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
+	BitSequence compact[SWIFFT_COMPACT_BLOCK_SIZE]);
+
+//! \brief Sets a constant value at each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the constant value to set, per block.
+void SWIFFT_ConstSetMultiple(int nblocks, BitSequence * output,
+	const int16_t * operand);
+
+//! \brief Adds a constant value to each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the constant value to add, per block.
+void SWIFFT_ConstAddMultiple(int nblocks, BitSequence * output,
+	const int16_t * operand);
+
+//! \brief Subtracts a constant value from each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the constant value to subtract, per block.
+void SWIFFT_ConstSubMultiple(int nblocks, BitSequence * output,
+	const int16_t * operand);
+
+//! \brief Multiply a constant value into each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the constant value to multiply by, per block.
+void SWIFFT_ConstMulMultiple(int nblocks, BitSequence * output,
+	const int16_t * operand);
+
+//! \brief Sets a SWIFFT hash value to another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify.
+//! \param[in] operand the hash value to set to.
+void SWIFFT_SetMultiple(int nblocks, BitSequence * output,
+	const BitSequence * operand);
+
+//! \brief Adds a SWIFFT hash value to another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify.
+//! \param[in] operand the hash value to add.
+void SWIFFT_AddMultiple(int nblocks, BitSequence * output,
+	const BitSequence * operand);
+
+//! \brief Subtracts a SWIFFT hash value from another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify.
+//! \param[in] operand the hash value to subtract.
+void SWIFFT_SubMultiple(int nblocks, BitSequence * output,
+	const BitSequence * operand);
+
+//! \brief Multiplies a SWIFFT hash value from another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify.
+//! \param[in] operand the hash value to multiply by.
+void SWIFFT_MulMultiple(int nblocks, BitSequence * output,
+	const BitSequence * operand);
 
 //! \brief Computes the result of a SWIFFT operation.
 //! The result is composable with other hash values.

--- a/include/libswifft/swifft_iset.inl
+++ b/include/libswifft/swifft_iset.inl
@@ -60,6 +60,13 @@ void SWIFFT_ISET_NAME(SWIFFT_ConstSub_)(BitSequence output[SWIFFT_OUTPUT_BLOCK_S
 void SWIFFT_ISET_NAME(SWIFFT_ConstMul_)(BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
         const int16_t operand);
 
+//! \brief Sets a SWIFFT hash value to another, element-wise.
+//!
+//! \param[in,out] output the hash value of SWIFFT to modify.
+//! \param[in] operand the hash value to set to.
+void SWIFFT_ISET_NAME(SWIFFT_Set_)(BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
+        const BitSequence operand[SWIFFT_OUTPUT_BLOCK_SIZE]);
+
 //! \brief Adds a SWIFFT hash value to another, element-wise.
 //!
 //! \param[in,out] output the hash value of SWIFFT to modify.
@@ -98,6 +105,98 @@ void SWIFFT_ISET_NAME(SWIFFT_Compute_)(const BitSequence input[SWIFFT_INPUT_BLOC
 void SWIFFT_ISET_NAME(SWIFFT_ComputeSigned_)(const BitSequence input[SWIFFT_INPUT_BLOCK_SIZE],
         const BitSequence sign[SWIFFT_INPUT_BLOCK_SIZE],
         BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE]);
+
+//! \brief Computes the FFT phase of SWIFFT for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in] input the blocks of input, each of 256 bytes (2048 bits).
+//! \param[in] sign the blocks of sign bits corresponding to blocks of input of 256 bytes (2048 bits).
+//! \param[in] m number of 8-elements in the input.
+//! \param[out] fftout the blocks of FFT-output elements, totaling nblocks*N*m.
+void SWIFFT_ISET_NAME(SWIFFT_fftMultiple_)(int nblocks, const BitSequence * LIBSWIFFT_RESTRICT input, const BitSequence * LIBSWIFFT_RESTRICT sign, int m, int16_t * LIBSWIFFT_RESTRICT fftout);
+
+//! \brief Computes the FFT-sum phase of SWIFFT for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in] ikey the SWIFFT key.
+//! \param[in] ifftout the blocks of FFT-output elements, totaling N*m
+//! \param[in] m number of 8-elements in the input.
+//! \param[out] iout the blocks of output elements, each of 64 double-bytes (1024 bits).
+void SWIFFT_ISET_NAME(SWIFFT_fftsumMultiple_)(int nblocks, const int16_t * LIBSWIFFT_RESTRICT ikey,
+        const int16_t * LIBSWIFFT_RESTRICT ifftout, int m, int16_t * LIBSWIFFT_RESTRICT iout);
+
+//! \brief Compacts a hash value of SWIFFT for multiple blocks.
+//! The result is not composable with other compacted hash values.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in] output the hash value of SWIFFT, of size 128 bytes (1024 bit) per block.
+//! \param[out] compact the compacted hash value of SWIFFT, of size 64 bytes (512 bit) per block.
+void SWIFFT_ISET_NAME(SWIFFT_CompactMultiple_)(int nblocks, const BitSequence * output,
+        BitSequence * compact);
+
+//! \brief Sets a constant value at each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the constant value to set, per block.
+void SWIFFT_ISET_NAME(SWIFFT_ConstSetMultiple_)(int nblocks, BitSequence * output,
+        const int16_t * operand);
+
+//! \brief Adds a constant value to each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the constant value to add, per block.
+void SWIFFT_ISET_NAME(SWIFFT_ConstAddMultiple_)(int nblocks, BitSequence * output,
+        const int16_t * operand);
+
+//! \brief Subtracts a constant value from each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block..
+//! \param[in] operand the constant value to subtract, per block.
+void SWIFFT_ISET_NAME(SWIFFT_ConstSubMultiple_)(int nblocks, BitSequence * output,
+        const int16_t * operand);
+
+//! \brief Multiply a constant value into each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block..
+//! \param[in] operand the constant value to multiply by, per block.
+void SWIFFT_ISET_NAME(SWIFFT_ConstMulMultiple_)(int nblocks, BitSequence * output,
+        const int16_t * operand);
+
+//! \brief Sets a SWIFFT hash value to another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block..
+//! \param[in] operand the hash value to set to, per block.
+void SWIFFT_ISET_NAME(SWIFFT_SetMultiple_)(int nblocks, BitSequence * output,
+        const BitSequence * operand);
+
+//! \brief Adds a SWIFFT hash value to another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block..
+//! \param[in] operand the hash value to add, per block.
+void SWIFFT_ISET_NAME(SWIFFT_AddMultiple_)(int nblocks, BitSequence * output,
+        const BitSequence * operand);
+
+//! \brief Subtracts a SWIFFT hash value from another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block..
+//! \param[in] operand the hash value to subtract, per block.
+void SWIFFT_ISET_NAME(SWIFFT_SubMultiple_)(int nblocks, BitSequence * output,
+        const BitSequence * operand);
+
+//! \brief Multiplies a SWIFFT hash value from another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block..
+//! \param[in] operand the hash value to multiply by, per block.
+void SWIFFT_ISET_NAME(SWIFFT_MulMultiple_)(int nblocks, BitSequence * output,
+        const BitSequence * operand);
 
 //! \brief Computes the result of multiple SWIFFT operations.
 //! The result is composable with other hash values.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,12 +67,12 @@ foreach(SWIFFT_FILE
 	${CMAKE_CURRENT_BINARY_DIR}/swifft_so_dummy.c
 	${SWIFFT_SRC_FILES}
 )
-	set_source_files_properties(${SWIFFT_FILE} PROPERTIES COMPILE_FLAGS ${SWIFFT_DEFAULT_FILE_COMPILE_FLAGS})
+	set_source_files_properties(${SWIFFT_FILE} PROPERTIES COMPILE_FLAGS "${SWIFFT_DEFAULT_FILE_COMPILE_FLAGS}")
 endforeach()
 
-set_source_files_properties(swifft_avx.c    PROPERTIES COMPILE_FLAGS -mavx)
-set_source_files_properties(swifft_avx2.c   PROPERTIES COMPILE_FLAGS -mavx2)
-set_source_files_properties(swifft_avx512.c PROPERTIES COMPILE_FLAGS -mavx512f)
+set_source_files_properties(swifft_avx.c    PROPERTIES COMPILE_FLAGS "${SWIFFT_DEFAULT_FILE_COMPILE_FLAGS} -mavx")
+set_source_files_properties(swifft_avx2.c   PROPERTIES COMPILE_FLAGS "${SWIFFT_DEFAULT_FILE_COMPILE_FLAGS} -mavx2")
+set_source_files_properties(swifft_avx512.c PROPERTIES COMPILE_FLAGS "${SWIFFT_DEFAULT_FILE_COMPILE_FLAGS} -mavx512f")
 
 foreach(SWIFFT_TARGET
 	swifft_static

--- a/src/swifft.c
+++ b/src/swifft.c
@@ -142,6 +142,16 @@ void SWIFFT_ConstMul(BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
 	SWIFFT_ISET_NAME(SWIFFT_ConstMul_)(output, operand);
 }
 
+//! \brief Sets a SWIFFT hash value to another, element-wise.
+//!
+//! \param[in,out] output the hash value of SWIFFT to modify.
+//! \param[in] operand the hash value to set to.
+void SWIFFT_Set(BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
+	const BitSequence operand[SWIFFT_OUTPUT_BLOCK_SIZE])
+{
+	SWIFFT_ISET_NAME(SWIFFT_Set_)(output, operand);
+}
+
 //! \brief Adds a SWIFFT hash value to another, element-wise.
 //!
 //! \param[in,out] output the hash value of SWIFFT to modify.
@@ -194,6 +204,131 @@ void SWIFFT_ComputeSigned(const BitSequence input[SWIFFT_INPUT_BLOCK_SIZE],
 	BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE])
 {
 	SWIFFT_ISET_NAME(SWIFFT_ComputeSigned_)(input, sign, output);
+}
+
+//! \brief Computes the FFT phase of SWIFFT for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in] input the blocks of input, each of 256 bytes (2048 bits).
+//! \param[in] sign the blocks of sign bits corresponding to blocks of input of 256 bytes (2048 bits).
+//! \param[in] m number of 8-elements in the input.
+//! \param[out] fftout the blocks of FFT-output elements, totaling N*m.
+void SWIFFT_fftMultiple(int nblocks, const BitSequence * LIBSWIFFT_RESTRICT input, const BitSequence * LIBSWIFFT_RESTRICT sign, int m, int16_t * LIBSWIFFT_RESTRICT fftout)
+{
+	SWIFFT_ISET_NAME(SWIFFT_fftMultiple_)(nblocks, input, sign, m, fftout);
+}
+
+//! \brief Computes the FFT-sum phase of SWIFFT for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in] ikey the SWIFFT key.
+//! \param[in] ifftout the blocks of FFT-output elements, totaling N*m
+//! \param[in] m number of 8-elements in the input.
+//! \param[out] iout the blocks of output elements, each of 64 double-bytes (1024 bits).
+void SWIFFT_fftsumMultiple(int nblocks, const int16_t * LIBSWIFFT_RESTRICT ikey,
+        const int16_t * LIBSWIFFT_RESTRICT ifftout, int m, int16_t * LIBSWIFFT_RESTRICT iout)
+{
+	SWIFFT_ISET_NAME(SWIFFT_fftsumMultiple_)(nblocks, ikey, ifftout, m, iout);
+}
+
+//! \brief Compacts a hash value of SWIFFT for multiple blocks.
+//! The result is not composable with other compacted hash values.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in] output the hash value of SWIFFT, of size 128 bytes (1024 bit).
+//! \param[out] compact the compacted hash value of SWIFFT, of size 64 bytes (512 bit).
+void SWIFFT_CompactMultiple(int nblocks, const BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE],
+        BitSequence compact[SWIFFT_COMPACT_BLOCK_SIZE])
+{
+	SWIFFT_ISET_NAME(SWIFFT_CompactMultiple_)(nblocks, output, compact);
+}
+
+//! \brief Sets a constant value at each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the constant value to set, per block.
+void SWIFFT_ConstSetMultiple(int nblocks, BitSequence * output,
+        const int16_t * operand)
+{
+	SWIFFT_ISET_NAME(SWIFFT_ConstSetMultiple_)(nblocks, output, operand);
+}
+
+//! \brief Adds a constant value to each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the constant value to add, per block.
+void SWIFFT_ConstAddMultiple(int nblocks, BitSequence * output,
+        const int16_t * operand)
+{
+	SWIFFT_ISET_NAME(SWIFFT_ConstAddMultiple_)(nblocks, output, operand);
+}
+
+//! \brief Subtracts a constant value from each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the constant value to subtract, per block.
+void SWIFFT_ConstSubMultiple(int nblocks, BitSequence * output,
+        const int16_t * operand)
+{
+	SWIFFT_ISET_NAME(SWIFFT_ConstSubMultiple_)(nblocks, output, operand);
+}
+
+//! \brief Multiply a constant value into each SWIFFT hash value element for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the constant value to multiply by, per block.
+void SWIFFT_ConstMulMultiple(int nblocks, BitSequence * output,
+        const int16_t * operand)
+{
+	SWIFFT_ISET_NAME(SWIFFT_ConstMulMultiple_)(nblocks, output, operand);
+}
+
+//! \brief Sets a SWIFFT hash value to another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the hash value to set to, per block.
+void SWIFFT_SetMultiple(int nblocks, BitSequence * output,
+        const BitSequence * operand)
+{
+	SWIFFT_ISET_NAME(SWIFFT_SetMultiple_)(nblocks, output, operand);
+}
+
+//! \brief Adds a SWIFFT hash value to another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the hash value to add, per block.
+void SWIFFT_AddMultiple(int nblocks, BitSequence * output,
+        const BitSequence * operand)
+{
+	SWIFFT_ISET_NAME(SWIFFT_AddMultiple_)(nblocks, output, operand);
+}
+
+//! \brief Subtracts a SWIFFT hash value from another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the hash value to subtract, per block.
+void SWIFFT_SubMultiple(int nblocks, BitSequence * output,
+        const BitSequence * operand)
+{
+	SWIFFT_ISET_NAME(SWIFFT_SubMultiple_)(nblocks, output, operand);
+}
+
+//! \brief Multiplies a SWIFFT hash value from another, element-wise, for multiple blocks.
+//!
+//! \param[in] nblocks the number of blocks to operate on.
+//! \param[in,out] output the hash value of SWIFFT to modify, per block.
+//! \param[in] operand the hash value to multiply by, per block.
+void SWIFFT_MulMultiple(int nblocks, BitSequence * output,
+        const BitSequence * operand)
+{
+	SWIFFT_ISET_NAME(SWIFFT_MulMultiple_)(nblocks, output, operand);
 }
 
 //! \brief Computes the result of multiple SWIFFT operations.


### PR DESCRIPTION
For https://github.com/gvilitechltd/LibSWIFFT/issues/16