### PR TITLE
Improve documentation

### DIFF
--- a/CODE-DESIGN.md
+++ b/CODE-DESIGN.md
@@ -1,0 +1,96 @@
+# Design of LibSWIFFT Code
+
+At a high level, LibSWIFFT includes a layer of C code that provides the C API
+and a layer of C++ code on top of it that provides the C++ API. New features are
+normally added to the C layer and then wrapped by the C++ layer.
+
+The C layer is composed of the main API and the microarchitecture-specific APIs,
+discussed in more detail below. In regular use cases, one would normally use the
+main API only, which selects the best microarchitecture-specific API for the
+platform the library was built for. In more sophisticated use cases, one could
+use a microarchitecture-specific APIs directly, e.g., to provide an optimized
+feature. The main C and C++ APIs are respectively provided by the `swifft.h` and
+`swifft.hpp` headers.
+
+## File and Directory Structure
+
+LibSWIFFT has the following file and directory structure:
+
+| File or Directory              | Description                                           |
+| :----------------------------- | :---------------------------------------------------- |
+| - `include`                    | root directory of headers                             |
+|  - `libswifft`                 | directory of LibSWIFFT headers                        |
+|   - `common.h`                 | LibSWIFFT public C common definitions                 |
+|   - `swifft.h`                 | LibSWIFFT public C API                                |
+|   - `swifft.hpp`               | LibSWIFFT public C++ API                              |
+|   - `swifft_avx.h`             | LibSWIFFT public C API for AVX                        |
+|   - `swifft_avx2.h`            | LibSWIFFT public C API for AVX2                       |
+|   - `swifft_avx512.h`          | LibSWIFFT public C API for AVX512                     |
+|   - `swifft_common.h`          | LibSWIFFT public C definitions                        |
+|   - `swifft_iset.inl`          | LibSWIFFT public C API expansion for instruction-sets |
+|   - `swifft_ver.h`             | LibSWIFFT public C API                                |
+| - `src`                        | directory of LibSWIFFT sources                        |
+|  - `swifft.c`                  | LibSWIFFT public C implementation                     |
+|  - `swifft.inl`                | LibSWIFFT internal C code expansion                   |
+|  - `swifft_avx.c`              | LibSWIFFT public C implementation for AVX             |
+|  - `swifft_avx2.c`             | LibSWIFFT public C implementation for AVX2            |
+|  - `swifft_avx512.c`           | LibSWIFFT public C implementation for AVX512          |
+|  - `swifft_impl.inl`           | LibSWIFFT internal C definitions                      |
+|  - `swifft_keygen.cpp`         | LibSWIFFT internal C code generation                  |
+|  - `swifft_ops.inl`            | LibSWIFFT internal C code expansion                   |
+
+## Main API
+
+The main C API has the following organization:
+
+- **FFT functions**: `SWIFFT_fft{,sum}`. These are the two low-level stages in a
+  SWIFFT hash computation and are normally not used directly.
+- **Transformation functions**: `SWIFFT_{Compute,Compact}`. These transform from
+  input to output and from output to compact forms.
+- **Arithmetic functions**: `SWIFFT_{,Const}{Set,Add,Sub,Mul}`. These set, add,
+  subtract, or multiply given two output forms or one output form and a constant
+  value.
+- **Functions for multiple blocks**: These are functions with `Multiple` as part
+  of their name. They operate on a number of blocks given as a parameter, rather 
+  than one block like the corresponding (i.e., without `Multiple`) single-block
+  functions.
+
+The main C++ API has the following organization:
+
+- **Wrapper classes**: `Swifft{Input,Output,Compact}`. These wrap input, output,
+  and compact buffers with automatic memory-alignment.
+- **Wrapper logical operators**: The wrapper classes provide equality and
+  inequality operators.
+- **Wrapper arithmetic operators**: The wrapper classes provides operators for
+  setting, adding, subtracting, and multiplying the current `SwifftOutput`
+  instance with another or with a constant value.
+
+## Microarchitecture-Specific APIs
+
+The microarchitecture-specific APIs have the following organization:
+
+- **Similarity to the main C API**: Each microarchitecure-specific function has
+  the same name as a corresponding main C API but with an added suffix, the
+  same parameter signature, and the same semantics.
+- **Name-suffix depending on microarchitecture feature**: There are 3 sets of
+  microarchitecture-specific functions corresponding to the 3 suffixes `_AVX`,
+  `_AVX2`, and `_AVX512` that respectively provide implementations optimized
+  for a microarchitecture supporting AVX, AVX2, and AVX512F instruction-sets.
+
+## Code Conventions
+
+The major code conventions used in LibSWIFFT are:
+
+- SWIFFT-related symbols of the C API start with `SWIFFT\_`.
+- Non-SWIFFT-related symbols of the C API start with `LIBSWIFFT\_`
+- Symbols in the C++ API are in namespace `LibSwifft`.
+- SWIFFT-related functions are thread-safe and constant-time.
+- Arguments are assumed non-overlapping in memory.
+
+## Conditional Compilation
+
+LibSWIFFT code uses conditional compilation directives with the following goals:
+
+- Prevent multiple compilations of the same header.
+- Compile microarchitecture-specific code only on a supporting platform.
+- Compile C++ or OpenMP code only on a supporting compiler.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # LibSWIFFT - A fast C/C++ library for the SWIFFT secure homomorphic hash function
 
 - [Official Repository](https://github.com/gvilitechltd/LibSWIFFT)
+- [Documentation](http://libswifft.readthedocs.io/en/latest/)
 - [![Documentation Status](https://readthedocs.org/projects/libswifft/badge/?version=latest)](http://libswifft.readthedocs.io/en/latest/)
 - [![Packaging Status](https://github.com/gvilitechltd/libswifft/actions/workflows/new-code.yml/badge.svg?branch=main)](https://github.com/gvilitechltd/libswifft/actions/workflows/new-code.yml/)
 - **Quick start on Linux**: Ensure `docker` is installed and runnable, clone this repository and go to its root directory, and run the command `docker build . && docker run --rm -it $(docker build -q .)` to build and test LibSWIFFT.
@@ -15,7 +16,7 @@ LibSWIFFT is a production-ready C/C++ library providing SWIFFT, one of the faste
 
 **Why another implementation of SWIFFT?** LibSWIFFT is a reliable building block for fast and scalable cryptographic protocols. It is simple to use and maintain, has clean APIs, is well documented and tested, and is at least as fast as other implementations of SWIFFT and often faster. Other implementations of SWIFFT are:
 
-- The [8-bit](https://github.com/anon1985/Swifft-avx2-8) and [16-bit](https://github.com/anon1985/K2SN-MSS/swifft16) AVX2 implementations for [K2SN-MSS](https://eprint.iacr.org/2019/442.pdf). Both are arguably not as easy to use nor as well documented and tested as LibSWIFFT. The former is slower and uses less memory while the latter is about as fast as LibSWIFFT for AVX2 yet does not support AVX512.
+- The [8-bit](https://github.com/anon1985/Swifft-avx2-8) and [16-bit](https://github.com/anon1985/K2SN-MSS/tree/master/swifft16) AVX2 implementations for [K2SN-MSS](https://eprint.iacr.org/2019/442.pdf). Both are arguably not as easy to use nor as well documented and tested as LibSWIFFT. The former is slower and uses less memory while the latter is about as fast as LibSWIFFT for AVX2 yet does not support AVX512.
 - [The original implementation](https://github.com/micciancio/SWIFFT) written in 2007. It is minimal non-production code. [The AVX2 implementation for K2SN-MSS](https://eprint.iacr.org/2019/442.pdf) is reported to be 25% faster.
 
 An invocation of the tests-executable of LibSWIFFT running single-threaded using AVX2 on an Intel Skylake microarchitecture (Intel(R) Core(TM) i7-10875H CPU @ 2.30GHz):
@@ -24,7 +25,12 @@ An invocation of the tests-executable of LibSWIFFT running single-threaded using
     Filters: swifft takes at most 2000 cycles per call
     running 1*10000000 rounds: cycles/rounds=1097.94 cycles/byte=4.28882 Giga-cycles/sec=2.30399 MB/sec=512.322 cycles/rdtsc=16
 
-demonstrates that LibSWIFFT is quite fast on short inputs (here, 256 bytes), often used in practical zero-knowledge proofs and post-quantum digital signatures. This is more than an order of magnitude faster than the [originally reported](https://www.alonrosen.net/PAPERS/lattices/swifft.pdf) 40MB/sec on a 3.2 GHz Intel Pentium 4. It also compares well with modern hash functions:
+demonstrates that LibSWIFFT is quite fast on short inputs (here, 256 bytes), often used in practical zero-knowledge proofs and post-quantum digital signatures. This is more than an order of magnitude faster than the [originally reported](https://www.alonrosen.net/PAPERS/lattices/swifft.pdf) 40MB/sec on a 3.2 GHz Intel Pentium 4. This is also faster than [K2SN-MSS's binary 16-bit SWIFFT function implementation](https://github.com/gvilitechltd/K2SN-MSS/tree/swifftperf) (for an input of 128 bytes), which is the fastest one in the K2SN-MSS implementation, for the same executaion settings, i.e. running single-threaded using AVX2 on an Intel Skylake microarchitecture (Intel(R) Core(TM) i7-10875H CPU @ 2.30GHz):
+
+    $ ./tester
+    1000000 SWIFFT16 rounds: cycles/round=737.363098 cycles/byte=5.760649
+
+It also compares well with modern hash functions:
 
 - [Blake3](https://github.com/BLAKE3-team/BLAKE3) - cryptographic hash function achieving about [3-to-4 cycles/byte using AVX512 on short inputs](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf) and are non-homomorphic nor facilitating proofs of knowledge of a preimage.
 - [Seahash](https://docs.rs/seahash/4.0.1/seahash/index.html) - a hash function achieving ~0.24 cycles/byte but is non-cryptographic.
@@ -56,7 +62,7 @@ LibSWIFFT was implemented with reference to the [SWIFFTX submission to NIST](htt
 6. Support for newer CPU instruction sets: AVX, AVX2, and AVX512.
 7. Over 30 test-cases providing excellent coverage of the APIs and the mathematical properties of SWIFFT.
 
-Formally, LibSWIFFT provides a single hash function that maps from an input domain `Z_2^{2048}` (taking 256B) to an output domain `Z_{257}^{64}` (taking 128B, at 2B per element) and then to a compact domain `Z_{256}^{65}` (taking 65B). The computation of the first map is done over `Z_{257}`. The homomorphism property applies to the input and output domains, but not to the compact domain, and is revealed when the binary-valued input domain is naturally embedded in `Z_{257}^{2048}`. Generally, it is computationally hard to find a binary-valued pre-image given an output computed as the sum of `N` outputs corresponding to known binary-valued pre-images. On the other hand, it is easy to find a small-valued pre-image (over `Z_{257}^{2048}`) when `N` is small, since it is simply the sum of the known pre-images due to the homomorphism property.
+Formally, LibSWIFFT provides a single hash function that maps from an input domain `Z_2^{2048}` (taking 256B) to an output domain `Z_{257}^{64}` (taking 128B, at 2B per element) and then to a compact domain `Z_{256}^{64}` (taking 64B). The computation of the first map is done over `Z_{257}`. The homomorphism property applies to the input and output domains, but not to the compact domain, and is revealed when the binary-valued input domain is naturally embedded in `Z_{257}^{2048}`. Generally, it is computationally hard to find a binary-valued pre-image given an output computed as the sum of `N` outputs corresponding to known binary-valued pre-images. On the other hand, it is easy to find a small-valued pre-image (over `Z_{257}^{2048}`) when `N` is small, since it is simply the sum of the known pre-images due to the homomorphism property.
 
 ## Using LibSWIFFT
 
@@ -73,7 +79,21 @@ The version of LibSWIFFT is provided by the API in `include/libswifft/swifft_ver
 
 The main LibSWIFFT C++ API is documented in `include/libswifft/swifft.hpp`.
 
-Refer to the [release checklist document](RELEASE-CHECKLIST.md) for how to generate the documentation for the APIs using doxygen.
+Please refer to:
+- the [release checklist document](RELEASE-CHECKLIST.md) for how to generate the documentation for the APIs using doxygen.
+- the [code design document](CODE-DESIGN.md) for details on the architecture and design of the LibSWIFFT code.
+- the [documentation](http://libswifft.readthedocs.io/en/latest/) for the complete details.
+
+An extended use of the LibSWIFFT API follows the following steps:
+
+- **Allocate buffers**: LibSWIFFT defines 3 types of buffers - input, output and compact. The input buffer `BitSequence input[SWIFFT_INPUT_BLOCK_SIZE]` holds a vector in `Z_2^{2048}` where each element takes 1 bit, the output buffer `BitSequence output[SWIFFT_OUTPUT_BLOCK_SIZE]` holds a vector in `Z_{257}^{64}` where each element takes 16 bits, and the compact buffer `BitSequence compact[SWIFFT_COMPACT_BLOCK_SIZE]` holds a value in `Z_{256}^64` taking 64 bytes.
+- **Populate input buffers**: An input buffer is populated in preparation for hashing. This is normally done by directly setting the bits in the input buffer. Each bit corresponds to an element of the vector with a value in `{0,1}`.
+- **Populate sign buffers**: A sign buffer is an input buffer whose bits are interpreted as sign bits. A 0-valued (resp. 1-valued) bit corresponds to a positive (resp. negative) sign. When an input buffer and a sign buffer are taken together, they define a vector in `{-1,0,1}^{2048}`.
+- **Compute output buffers**: The hash of an input buffer, with or without a sign buffer, is computed into an output buffer. This is normally done using `SWIFFT_Compute` or `SWIFFT_ComputeSigned`.
+- **Perform arithmetic operations with output buffers**: LibSWIFFT provides several arithemtic (homomorphic) operations involving output buffers whose result is put into an output buffer. The vectors of output buffers may be added, subtracted, or multiplied element-wise. See below for more details.
+- **Compact the output buffer**: The hash in the output buffer is compacted into the compact buffer. This is an optional operation, in that the hash in the output buffer may be sufficient for certain applications.
+
+A more restricted use of the LibSWIFFT API involves only the steps of allocating buffers, populating input buffers, and computing output buffers. 
 
 Typical code using the C API:
 
@@ -92,7 +112,7 @@ SWIFFT_Compute(input, sign, output); /* compute the hash of the signed input int
 SWIFFT_Compact(output, compact); /* optionally, compact the hash */
 ```
 
-Buffers must be memory-aligned in order to avoid a segmentation fault when passed to `LibSWIFFT` functions: statically allocated buffers should be aligned using `SWIFFT_ALIGN`, and dynamically allocated buffers should use an alignment of `SWIFFT_ALIGNMENT`, e.g., via `aligned_alloc` function in `stdlib.h`. The transformation functions `SWIFFT_{Compute,Compact}Multiple{,Signed}*` apply operations to multiple blocks. The arithmetic functions `SWIFFT_{Const,}{Set,Add,Sub,Mul}*` provide vectorized and homomorphic operations on an output block, while `SWIFFT_{Const,}{Set,Add,sub,Mul}Multiple*` provide corresponding operations to multiple blocks.
+Buffers must be memory-aligned in order to avoid a segmentation fault when passed to `LibSWIFFT` functions: statically allocated buffers should be aligned using `SWIFFT_ALIGN`, and dynamically allocated buffers should use an alignment of `SWIFFT_ALIGNMENT`, e.g., via `aligned_alloc` function in `stdlib.h`. The transformation functions `SWIFFT_ComputeMultiple{,Signed}*` and `SWIFFT_CompactMultiple` apply operations to multiple blocks. The arithmetic functions `SWIFFT_{Const,}{Set,Add,Sub,Mul}*` provide vectorized and homomorphic operations on an output block, while `SWIFFT_{Const,}{Set,Add,sub,Mul}Multiple*` provide corresponding operations to multiple blocks.
 
 Typical code using the C++ API:
 

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -41,9 +41,16 @@ Coverage tests are executed using a debug build:
 
 This procedure is specific to GCC builds and does not cover performance testing code.
 
-## Running doxygen
+## Generating Documentation
 
 To generate documentation:
+
+- Ensure `sphinx` documentation generator is installed and working
+- Ensure `doxygen` is installed and working
+- Go to the `docs` directory
+- Run `make html`
+
+The doxygen configuration was set up using these steps:
 
 - Run `doxygen -g doxygen.conf`
 - Edit `doxygen.conf`:
@@ -52,4 +59,5 @@ To generate documentation:
   - Set `RECURSIVE` to `YES`.
   - Set `EXTRACT_ALL` to `YES`
   - Set `EXCLUDE` to `build`
-- Run `doxygen doxygen.conf`
+
+The doxygen generation can be ran using `doxygen doxygen.conf`.

--- a/docs/code-design.rst
+++ b/docs/code-design.rst
@@ -1,0 +1,132 @@
+Design of LibSWIFFT Code
+========================
+
+At a high level, LibSWIFFT includes a layer of C code that provides the C API
+and a layer of C++ code on top of it that provides the C++ API. New features are
+normally added to the C layer and then wrapped by the C++ layer.
+
+The C layer is composed of the main API and the microarchitecture-specific APIs,
+discussed in more detail below. In regular use cases, one would normally use the
+main API only, which selects the best microarchitecture-specific API for the
+platform the library was built for. In more sophisticated use cases, one could
+use a microarchitecture-specific APIs directly, e.g., to provide an optimized
+feature. The main C and C++ APIs are respectively provided by the `swifft.h` and
+`swifft.hpp` headers.
+
+File and Directory Structure
+----------------------------
+
+LibSWIFFT has the following file and directory structure:
+
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+
+   * - File or Directory
+     - Description                                         
+   * - include
+     - root directory of headers                           
+   * - . libswifft
+     - directory of LibSWIFFT headers                      
+   * - . . :libswifft:`common.h`
+     - LibSWIFFT public C common definitions               
+   * - . . :libswifft:`swifft.h`
+     - LibSWIFFT public C API                              
+   * - . . :libswifft:`swifft.hpp`
+     - LibSWIFFT public C++ API                            
+   * - . . :libswifft:`swifft_avx.h`
+     - LibSWIFFT public C API for AVX                      
+   * - . . :libswifft:`swifft_avx2.h`
+     - LibSWIFFT public C API for AVX2                     
+   * - . . :libswifft:`swifft_avx512.h`
+     - LibSWIFFT public C API for AVX512                   
+   * - . . :libswifft:`swifft_common.h`
+     - LibSWIFFT public C definitions                      
+   * - . . :libswifft:`swifft_iset.inl`
+     - LibSWIFFT public C API expansion for instruction-sets
+   * - . . :libswifft:`swifft_ver.h`
+     - LibSWIFFT public C API                              
+   * -  src
+     - directory of LibSWIFFT sources                      
+   * - . :libswifft:`swifft.c`
+     - LibSWIFFT public C implementation                   
+   * - . :libswifft:`swifft.inl`
+     - LibSWIFFT internal C code expansion                 
+   * - . :libswifft:`swifft_avx.c`
+     - LibSWIFFT public C implementation for AVX           
+   * - . :libswifft:`swifft_avx2.c`
+     - LibSWIFFT public C implementation for AVX2          
+   * - . :libswifft:`swifft_avx512.c`
+     - LibSWIFFT public C implementation for AVX512        
+   * - . :libswifft:`swifft_impl.inl`
+     - LibSWIFFT internal C definitions                    
+   * - . :libswifft:`swifft_keygen.cpp`
+     - LibSWIFFT internal C code generation                
+   * - . :libswifft:`swifft_ops.inl`
+     - LibSWIFFT internal C code expansion                 
+
+Main API
+--------
+
+The main C API has the following organization:
+
+- **FFT functions**: :libswifft:`SWIFFT_fft`, :libswifft:`SWIFFT_fftsum`.
+  These are the two low-level stages in a SWIFFT hash computation and are
+  normally not used directly.
+- **Transformation functions**: :libswifft:`SWIFFT_Compute`,
+  :libswifft:`SWIFFT_Compact`. These transform from input to output and from
+  output to compact forms.
+- **Arithmetic functions**: :libswifft:`SWIFFT_Set`, :libswifft:`SWIFFT_Add`,
+  :libswifft:`SWIFFT_Sub`, :libswifft:`SWIFFT_Mul`,
+  :libswifft:`SWIFFT_ConstSet`, :libswifft:`SWIFFT_ConstAdd`,
+  :libswifft:`SWIFFT_ConstSub`, :libswifft:`SWIFFT_ConstMul`. These set, add,
+  subtract, or multiply given two output forms or one output form and a constant
+  value.
+- **Functions for multiple blocks**: These are functions with `Multiple` as part
+  of their name. They operate on a number of blocks given as a parameter, rather 
+  than one block like the corresponding (i.e., without `Multiple`) single-block
+  functions.
+
+The main C++ API has the following organization:
+
+- **Wrapper classes**: :libswifft:`SwifftInput`, :libswifft:`SwifftOutput`,
+  :libswifft:`SwifftCompact`. These wrap input, output, and compact buffers with
+  automatic memory-alignment.
+- **Wrapper logical operators**: The wrapper classes provide equality and
+  inequality operators.
+- **Wrapper arithmetic operators**: The wrapper classes provides operators for
+  setting, adding, subtracting, and multiplying the current `SwifftOutput`
+  instance with another or with a constant value.
+
+Microarchitecture-Specific APIs
+-------------------------------
+
+The microarchitecture-specific APIs have the following organization:
+
+- **Similarity to the main C API**: Each microarchitecure-specific function has
+  the same name as a corresponding main C API but with an added suffix, the
+  same parameter signature, and the same semantics.
+- **Name-suffix depending on microarchitecture feature**: There are 3 sets of
+  microarchitecture-specific functions corresponding to the 3 suffixes `_AVX`,
+  `_AVX2`, and `_AVX512` that respectively provide implementations optimized
+  for a microarchitecture supporting AVX, AVX2, and AVX512F instruction-sets.
+
+Code Conventions
+----------------
+
+Major code conventions used in LibSWIFFT are:
+
+- SWIFFT-related symbols of the C API start with `SWIFFT\_`.
+- Non-SWIFFT-related symbols of the C API start with `LIBSWIFFT\_`
+- Symbols in the C++ API are in namespace `LibSwifft`.
+- SWIFFT-related functions are thread-safe and constant-time.
+- Arguments are assumed non-overlapping in memory.
+
+Conditional Compilation
+-----------------------
+
+Major goals of LibSWIFFT code in using conditional compilation are:
+
+- Prevent a header for being compiled multiple times.
+- Compile microarchitecture-specific code only on a supporting platform.
+- Compile C++ or OpenMP code only on a supporting compiler.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,15 +31,26 @@ Fast
 ----
 
 LibSWIFFT is fast. Here is the output from a test-case of LibSwifft v1.0.0 that
-demonstrates hashing running at a rate of less than 5 cycles-per-byte
-single-threaded using AVX2 on an Intel Skylake microarchitecture (Intel(R)
-Core(TM) i7-10875H CPU @ 2.30GHz):
+demonstrates hashing (for an input of 256 bytes) running at a rate of less than
+5 cycles-per-byte single-threaded using AVX2 on an Intel Skylake
+microarchitecture (Intel(R) Core(TM) i7-10875H CPU @ 2.30GHz):
 
 .. code-block:: sh
 
     $ ./test/swifft_catch "swifft takes at most 2000 cycles per call"
     Filters: swifft takes at most 2000 cycles per call
     running 1*10000000 rounds: cycles/rounds=1097.94 cycles/byte=4.28882 Giga-cycles/sec=2.30399 MB/sec=512.322 cycles/rdtsc=16
+
+This is faster than the rate of the recent
+`K2SN-MSS's binary 16-bit SWIFFT function implementation <https://github.com/gvilitechltd/K2SN-MSS/tree/swifftperf>`_
+(for an input of 128 bytes) on the same execution settings, i.e. single-threaded
+using AVX2 on an Intel Skylake microarchitecture (Intel(R) Core(TM) i7-10875H
+CPU @ 2.30GHz):
+
+.. code-block:: sh
+
+   $ ./tester
+    1000000 SWIFFT16 rounds: cycles/round=737.363098 cycles/byte=5.760649
 
 LibSWIFFT supports microarchitectures with AVX, AVX2, and AVX512 instruction
 sets to take advantage of available hardware acceleration.
@@ -93,7 +104,6 @@ of buffers passed to LibSWIFFT functions. The equivalent code using the
     SwifftOutput output;
     /* after input is populated (not shown here), it is time to compute the hash: */
     SWIFFT_Compute(input.data, output.data); /* compute the hash of the input into the output */
-    SWIFFT_Compact(output.data, compact.data); /* optionally, compact the hash */
 
 :libswifft:`SwifftInput` and :libswifft:`SwifftOutput` are auto-memory-aligned.
 
@@ -168,6 +178,7 @@ The Community Guide explains how to participate in LibSWIFFT's community.
    :maxdepth: 2
 
    community-guide
+   code-design
 
 API Guide
 =========

--- a/docs/rationale.rst
+++ b/docs/rationale.rst
@@ -24,7 +24,14 @@ An invocation of the tests-executable of LibSWIFFT running single-threaded using
     Filters: swifft takes at most 2000 cycles per call
     running 1*10000000 rounds: cycles/rounds=1097.94 cycles/byte=4.28882 Giga-cycles/sec=2.30399 MB/sec=512.322 cycles/rdtsc=16
 
-demonstrates that LibSWIFFT is quite fast on short inputs (here, 256 bytes), often used in practical zero-knowledge proofs and post-quantum digital signatures. This is more than an order of magnitude faster than the `originally reported <https://www.alonrosen.net/PAPERS/lattices/swifft.pdf>`_ 40MB/sec on a 3.2 GHz Intel Pentium 4. It also compares well with modern hash functions:
+demonstrates that LibSWIFFT is quite fast on short inputs (here, 256 bytes), often used in practical zero-knowledge proofs and post-quantum digital signatures. This is more than an order of magnitude faster than the `originally reported <https://www.alonrosen.net/PAPERS/lattices/swifft.pdf>`_ 40MB/sec on a 3.2 GHz Intel Pentium 4. This is also faster than `K2SN-MSS's binary 16-bit SWIFFT function implementation <https://github.com/gvilitechltd/K2SN-MSS/tree/swifftperf>`_ (for an input of 128 bytes), which is the fastest one in the K2SN-MSS implementation, for the same executaion settings, i.e. running single-threaded using AVX2 on an Intel Skylake microarchitecture (Intel(R) Core(TM) i7-10875H CPU @ 2.30GHz):
+
+.. code-block:: sh
+
+    $ ./tester
+    1000000 SWIFFT16 rounds: cycles/round=737.363098 cycles/byte=5.760649
+
+It also compares well with modern hash functions:
 
 - `Blake3 <https://github.com/BLAKE3-team/BLAKE3>`_ - cryptographic hash function achieving about `3-to-4 cycles/byte using AVX512 on short inputs <https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf>`_ and are non-homomorphic nor facilitating proofs of knowledge of a preimage.
 - `Seahash <https://docs.rs/seahash/4.0.1/seahash/index.html>`_ - a hash function achieving ~0.24 cycles/byte but is non-cryptographic.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -4,7 +4,7 @@ User Guide
 Getting LibSWIFFT
 -----------------
 
-LibSWIFFT is available on `GitHub <https://github.com/gvilitechltd/LibSWIFFT>`.
+LibSWIFFT is available on `GitHub <https://github.com/gvilitechltd/LibSWIFFT>`_.
 The code repository can be cloned using `git <https://git-scm.com>`_:
 
 .. code-block:: sh
@@ -106,6 +106,20 @@ The version of LibSWIFFT is provided by the API in :libswifft:`swifft_ver.h`.
 
 The main LibSWIFFT C++ API is documented in :libswifft:`swifft.hpp`.
 
+An extended use of the LibSWIFFT API follows the following steps:
+
+.. |_| unicode:: 0xA0
+   :trim:
+
+- **Allocate buffers**: LibSWIFFT defines 3 types of buffers - input, output and compact. The input buffer ':libswifft:`BitSequence` |_| input[:libswifft:`SWIFFT_INPUT_BLOCK_SIZE`]' holds a vector in `Z_2^{2048}` where each element takes 1 bit, the output buffer ':libswifft:`BitSequence` |_| output[:libswifft:`SWIFFT_OUTPUT_BLOCK_SIZE`]' holds a vector in `Z_{257}^{64}` where each element takes 16 bits, and the compact buffer ':libswifft:`BitSequence` |_| compact[:libswifft:`SWIFFT_COMPACT_BLOCK_SIZE`]' holds a value in `Z_{256}^64` taking 64 bytes.
+- **Populate input buffers**: An input buffer is populated in preparation for hashing. This is normally done by directly setting the bits in the input buffer. Each bit corresponds to an element of the vector with a value in `{0,1}`.
+- **Populate sign buffers**: A sign buffer is an input buffer whose bits are interpreted as sign bits. A 0-valued (resp. 1-valued) bit corresponds to a positive (resp. negative) sign. When an input buffer and a sign buffer are taken together, they define a vector in `{-1,0,1}^{2048}`.
+- **Compute output buffers**: The hash of an input buffer, with or without a sign buffer, is computed into an output buffer. This is normally done using :libswifft:`SWIFFT_Compute` or :libswifft:`SWIFFT_ComputeSigned`.
+- **Perform arithmetic operations with output buffers**: LibSWIFFT provides several arithemtic (homomorphic) operations involving output buffers whose result is put into an output buffer. The vectors of output buffers may be added, subtracted, or multiplied element-wise. See below for more details.
+- **Compact the output buffer**: The hash in the output buffer is compacted into the compact buffer. This is an optional operation, in that the hash in the output buffer may be sufficient for certain applications.
+
+A more restricted use of the LibSWIFFT API involves only the steps of allocating buffers, populating input buffers, and computing output buffers.
+
 Typical code using the C API:
 
 .. code-block:: c
@@ -123,7 +137,8 @@ Typical code using the C API:
     SWIFFT_Compute(input, sign, output); /* compute the hash of the signed input into the output */
     SWIFFT_Compact(output, compact); /* optionally, compact the hash */
 
-Buffers must be memory-aligned in order to avoid a segmentation fault when passed to `LibSWIFFT` functions: statically allocated buffers should be aligned using `SWIFFT_ALIGN`, and dynamically allocated buffers should use an alignment of `SWIFFT_ALIGNMENT`, e.g., via `aligned_alloc` function in `stdlib.h`. The transformation functions `SWIFFT_{Compute,Compact}Multiple{,Signed}*` apply operations to multiple blocks. The arithmetic functions `SWIFFT_{Const,}{Set,Add,Sub,Mul}*` provide vectorized and homomorphic operations on an output block, while `SWIFFT_{Const,}{Set,Add,sub,Mul}Multiple*` provide corresponding operations to multiple blocks.
+Buffers must be memory-aligned in order to avoid a segmentation fault when passed to `LibSWIFFT` functions: statically allocated buffers should be aligned using `SWIFFT_ALIGN`, and dynamically allocated buffers should use an alignment of `SWIFFT_ALIGNMENT`, e.g., via `aligned_alloc` function in `stdlib.h`. The transformation functions :libswifft:`SWIFFT_ComputeMultiple`, :libswifft:`SWIFFT_ComputeSignedMultiple` and :libswifft:`SWIFFT_CompactMultiple` apply operations to multiple blocks. The arithmetic functions :libswifft:`SWIFFT_ConstSet`, :libswifft:`SWIFFT_ConstAdd`, :libswifft:`SWIFFT_ConstSub`, :libswifft:`SWIFFT_ConstMul`, :libswifft:`SWIFFT_Set`, :libswifft:`SWIFFT_Add`, :libswifft:`SWIFFT_Sub`, :libswifft:`SWIFFT_Mul` provide vectorized and homomorphic operations on an output block, while :libswifft:`SWIFFT_ConstSetMultiple`, :libswifft:`SWIFFT_ConstAddMultiple`, :libswifft:`SWIFFT_ConstSubMultiple`, :libswifft:`SWIFFT_ConstMulMultiple`, :libswifft:`SWIFFT_SetMultiple`, :libswifft:`SWIFFT_AddMultiple`, :libswifft:`SWIFFT_SubMultiple`, :libswifft:`SWIFFT_Mul` provide corresponding operations to multiple blocks.
+
 
 Typical code using the C++ API:
 
@@ -143,5 +158,5 @@ Typical code using the C++ API:
     SWIFFT_Compute(input.data, sign.data, output.data); /* compute the hash of the signed input into the output */
     SWIFFT_Compact(output.data, compact.data); /* optionally, compact the hash */
 
-Assignment and equality operators are available for `Swifft{Input,Output,Compact}` instances. Arithemtic and arithmetic-assignment operators, corresponding to the arithmetic functions in the C API, are available for `SwifftOutput` instances.
+Assignment and equality operators are available for :libswifft:`SwifftInput`, :libswifft:`SwifftOutput`, :libswifft:`SwifftCompact` instances. Arithemtic and arithmetic-assignment operators, corresponding to the arithmetic functions in the C API, are available for :libswifft:`SwifftOutput` instances.
 


### PR DESCRIPTION
* [Elaborate on typical usage of the C and C++ APIs](https://github.com/gvilitechltd/LibSWIFFT/issues/28)
* [Add a visible link to documentation at read-the-docs](https://github.com/gvilitechltd/LibSWIFFT/issues/25)
* [Add architecture/design documentation](https://github.com/gvilitechltd/LibSWIFFT/issues/24)
* [Add performance comparison to K2SN-MSS's 16-bit SWIFFT function](https://github.com/gvilitechltd/LibSWIFFT/issues/22)
* [Document required setup for docs to build](https://github.com/gvilitechltd/LibSWIFFT/issues/21)